### PR TITLE
fix(timeslots): scope main storefront to site=main

### DIFF
--- a/src/app/services/order-service.service.ts
+++ b/src/app/services/order-service.service.ts
@@ -55,7 +55,7 @@ export class OrderServiceService {
     return this.http.patch(`${this.apiUrl}/orders/${orderId}/updateOrderDetails`, body);
   }
   getAvailableTimeSlots() {
-    return this.http.get(`${this.apiUrl}/orders/availableTimes/6`);
+    return this.http.get(`${this.apiUrl}/orders/availableTimes/6?site=main`);
   }
   getAvailableSpecialSlots(id) {
     return this.http.get(`${this.apiUrl}/orders/availableSpecialTimes/${id}`);


### PR DESCRIPTION
## Summary

Companion to backend [PR #21](https://github.com/csherm08/frese_backend/pull/21). The Angular order-service is the main bakery's customer-facing site; once the backend's `?site=` filter is live, this passes `site=main` to keep main's timeslot picker scoped to main slots.

Defensive — today there are no PP slot rows in the DB, so behavior is unchanged. But once PP slot generation is wired up, an unfiltered call would surface PP slots in the main picker. This forecloses that.

## Test plan
- [ ] Backend PR #21 must be deployed first.
- [ ] After deploy, time picker on the Angular order site shows the same Fri/Sat options as before.
- [ ] Network tab confirms `?site=main` is on the request.