### PR TITLE
Hide catering types from legacy storefront menu

### DIFF
--- a/src/app/frese-bakery/frese-bakery.page.ts
+++ b/src/app/frese-bakery/frese-bakery.page.ts
@@ -324,7 +324,11 @@ export class FreseBakeryPage implements OnInit {
     this.productsService.productsUpdated.subscribe((vals) => {
     });
     this.dataService.getProductTypes().subscribe(types => {
-      this.productTypes = types.filter(t => t.name !== 'Plug Power');
+      // Hide Plug Power and every catering type (generic "Catering" + the
+      // per-menu catering types) from the menu category list.
+      this.productTypes = types.filter(t =>
+        t.name !== 'Plug Power' && !(t.name && t.name.toLowerCase().includes('catering'))
+      );
     });
     const timeout = 200;
     let i = 0;

--- a/src/app/products.service.ts
+++ b/src/app/products.service.ts
@@ -33,13 +33,17 @@ export class ProductsService {
   }
   getProducts() {
     const special = this.types.find(t => t.name === 'Special');
-    const catering = this.types.find(t => t.name === 'Catering');
     const plugPower = this.types.find(t => t.name === 'Plug Power');
-    // Filter out Special, Superbowl (typeId 10), Catering, Plug Power (second-location catalog)
+    // Every catering type: generic "Catering" + the per-menu catering types
+    // (Full Service / Barbecue / A La Carte Catering). Kept out of the menu.
+    const cateringIds = this.types
+      .filter(t => t.name && t.name.toLowerCase().includes('catering'))
+      .map(t => t.id);
+    // Filter out Special, Superbowl (typeId 10), all Catering types, Plug Power (second-location catalog)
     return this.products.filter(p => {
       if (special && p.typeId === special.id) return false;
       if (p.typeId === 10) return false; // Superbowl Special
-      if (catering && p.typeId === catering.id) return false;
+      if (cateringIds.includes(p.typeId)) return false;
       if (plugPower && p.typeId === plugPower.id) return false;
       return true;
     });


### PR DESCRIPTION
Excludes all catering-named types from getProducts() and the menu category headers, matching the React storefront. **Do not merge/deploy yet** — awaiting confirmation of the legacy app's deploy mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)